### PR TITLE
feat(authentification): Page de connexion et création d'utilisateur

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
             const match = branch.match(/^(\d+)-/);
             if (!match) return;
 
-            const issueNumber = parseInt(match[1])+1;
+            const issueNumber = parseInt(match[1]);
             const issue = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/src/components/layout/HeaderBar.vue
+++ b/src/components/layout/HeaderBar.vue
@@ -32,17 +32,8 @@
         <!-- Utilisateur connecté -->
         <template v-if="isAuthenticated">
           <NText depth="3"> Connecté en tant que {{ user?.username }} </NText>
-          <NButton
-            size="small"
-            @click="
-              () => {
-                authStore.logout()
-                goToLogin()
-              }
-            "
-          >
-            Déconnexion
-          </NButton>
+
+          <NButton size="small" @click="handleLogout"> Déconnexion </NButton>
         </template>
 
         <template v-else>
@@ -74,5 +65,10 @@ function goToLogin() {
 
 function goToRegister() {
   router.push('/register')
+}
+
+function handleLogout() {
+  authStore.logout()
+  goToLogin()
 }
 </script>

--- a/src/components/layout/HeaderBar.vue
+++ b/src/components/layout/HeaderBar.vue
@@ -6,6 +6,7 @@
     <NSpace justify="space-between" align="center" style="height: 56px">
       <NSpace align="center" :size="16">
         <RouterLink to="/">TCG SPA</RouterLink>
+
         <NButton
           tag="a"
           :href="`${apiBaseUrl.replace('/api', '')}/api-docs`"
@@ -15,6 +16,7 @@
         >
           API Docs
         </NButton>
+
         <NButton
           tag="a"
           href="https://making-rerun-61323218.figma.site/"
@@ -25,14 +27,52 @@
           Maquettes
         </NButton>
       </NSpace>
+
       <NSpace align="center" :size="16">
-        <NText depth="3">Renseigner le user connecté ici</NText>
-        <NButton size="small">Déconnexion</NButton>
+        <!-- Utilisateur connecté -->
+        <template v-if="isAuthenticated">
+          <NText depth="3"> Connecté en tant que {{ user?.username }} </NText>
+          <NButton
+            size="small"
+            @click="
+              () => {
+                authStore.logout()
+                goToLogin()
+              }
+            "
+          >
+            Déconnexion
+          </NButton>
+        </template>
+
+        <template v-else>
+          <NButton size="small" @click="goToRegister"> Inscription </NButton>
+          <NButton size="small" @click="goToLogin"> Connexion </NButton>
+        </template>
       </NSpace>
     </NSpace>
   </NLayoutHeader>
 </template>
 
 <script setup lang="ts">
+import { NButton, NLayoutHeader, NSpace, NText } from 'naive-ui'
+import { storeToRefs } from 'pinia'
+import { RouterLink, useRouter } from 'vue-router'
+
+import { useAuthStore } from '@/store/auth.store'
+
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL as string
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const { user, isAuthenticated } = storeToRefs(authStore)
+
+function goToLogin() {
+  router.push('/login')
+}
+
+function goToRegister() {
+  router.push('/register')
+}
 </script>

--- a/src/pages/ConnexionPage.vue
+++ b/src/pages/ConnexionPage.vue
@@ -1,0 +1,93 @@
+<script lang="ts" setup>
+import type { FormRules } from 'naive-ui'
+import { NButton, NCard, NForm, NFormItem, NInput, NSpace } from 'naive-ui'
+import { ref } from 'vue'
+import { RouterLink, useRouter } from 'vue-router'
+
+import { useApi } from '@/composables/useApi'
+import { ROUTES } from '@/router'
+import { useAuthStore } from '@/store/auth.store'
+
+import type { SignInPayload } from '../types/auth'
+
+const router = useRouter()
+
+const modelRef = ref<SignInPayload>({
+  email: '',
+  password: '',
+})
+
+const rules: FormRules = {
+  email: [
+    { required: true, message: 'Email requis', trigger: ['input', 'blur'] },
+  ],
+  password: [
+    {
+      required: true,
+      message: 'Mot de passe requis',
+      trigger: ['input', 'blur'],
+    },
+  ],
+}
+
+const errorMessage = ref('')
+const loading = ref(false)
+
+const authStore = useAuthStore()
+const api = useApi()
+
+const handleSubmit = async () => {
+  errorMessage.value = ''
+  loading.value = true
+
+  try {
+    const response = await api.signIn(modelRef.value)
+
+    authStore.login(response.token, response.user)
+
+    router.push(ROUTES.HOME)
+  } catch {
+    errorMessage.value = 'Erreur lors de la connexion'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <NCard title="Connexion" style="max-width: 400px; margin: 40px auto">
+    <NForm ref="formRef" :model="modelRef" :rules="rules">
+      <NFormItem path="email" label="Email">
+        <NInput
+          v-model:value="modelRef.email"
+          placeholder="votre@email.com"
+          @keydown.enter.prevent
+        />
+      </NFormItem>
+
+      <NFormItem path="password" label="Mot de passe">
+        <NInput
+          v-model:value="modelRef.password"
+          type="password"
+          placeholder="********"
+          @keydown.enter.prevent
+        />
+      </NFormItem>
+
+      <div style="display: flex; justify-content: flex-end; margin-top: 12px">
+        <NButton type="primary" :loading="loading" round @click="handleSubmit">
+          Se connecter
+        </NButton>
+      </div>
+
+      <NSpace style="margin-top: 12px">
+        Pas encore de compte ?
+        <RouterLink :to="ROUTES.REGISTER">S'inscrire</RouterLink>
+      </NSpace>
+
+      <p v-if="errorMessage" style="color: red">
+        {{ errorMessage }}
+      </p>
+    </NForm>
+  </NCard>
+</template>

--- a/src/pages/InscriptionPage.vue
+++ b/src/pages/InscriptionPage.vue
@@ -1,0 +1,109 @@
+<script lang="ts" setup>
+import type { FormRules } from 'naive-ui'
+import { NButton, NCard, NForm, NFormItem, NInput, NSpace } from 'naive-ui'
+import { ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useRouter } from 'vue-router'
+
+import { useApi } from '@/composables/useApi'
+import { ROUTES } from '@/router'
+
+import { useAuthStore } from '../store/auth.store'
+import type { SignUpPayload } from '../types/auth'
+
+const router = useRouter()
+const authStore = useAuthStore()
+const api = useApi()
+
+const modelRef = ref<SignUpPayload>({
+  email: '',
+  password: '',
+  username: '',
+})
+
+const rules: FormRules = {
+  username: [
+    {
+      required: true,
+      message: "Nom d'utilisateur requis",
+      trigger: ['input', 'blur'],
+    },
+  ],
+  email: [
+    { required: true, message: 'Email requis', trigger: ['input', 'blur'] },
+  ],
+  password: [
+    {
+      required: true,
+      message: 'Mot de passe requis',
+      trigger: ['input', 'blur'],
+    },
+  ],
+}
+
+const loading = ref(false)
+const errorMessage = ref('')
+
+//RG2, RG3, RG4
+
+const handleSubmit = async () => {
+  errorMessage.value = ''
+  loading.value = true
+
+  try {
+    // Appel API réel
+    const response = await api.signUp(modelRef.value)
+
+    authStore.login(response.token, response.user) //RG4
+
+    router.push(ROUTES.HOME)
+  } catch {
+    errorMessage.value = 'Erreur lors de l inscription' // RG3
+  } finally {
+    loading.value = false // RG2
+  }
+}
+</script>
+
+<template>
+  <NCard title="Inscription" style="max-width: 400px; margin: 40px auto">
+    <NForm ref="formRef" :model="modelRef" :rules="rules">
+      <NFormItem path="username" label="Nom d'utilisateur">
+        <NInput
+          v-model:value="modelRef.username"
+          type="text"
+          placeholder="Nom d'utilisateur"
+          @keydown.enter.prevent
+        />
+      </NFormItem>
+
+      <NFormItem path="email" label="Email">
+        <NInput
+          v-model:value="modelRef.email"
+          placeholder="votre@email.com"
+          @keydown.enter.prevent
+        />
+      </NFormItem>
+
+      <NFormItem path="password" label="Mot de passe">
+        <NInput
+          v-model:value="modelRef.password"
+          type="password"
+          placeholder="********"
+          @keydown.enter.prevent
+        />
+      </NFormItem>
+
+      <div style="display: flex; justify-content: flex-end; margin-top: 12px">
+        <NButton type="primary" round @click="handleSubmit">
+          S'inscrire
+        </NButton>
+      </div>
+
+      <NSpace style="margin-top: 12px">
+        Déjà un compte ?
+        <RouterLink :to="ROUTES.CONNEXION">Se connecter</RouterLink>
+      </NSpace>
+    </NForm>
+  </NCard>
+</template>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,13 +1,27 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import ConnexionPage from './pages/ConnexionPage.vue'
 import HomePage from './pages/HomePage.vue'
+import InscriptionPage from './pages/InscriptionPage.vue'
 
 export const ROUTES = {
   HOME: '/',
+  CONNEXION: '/login',
+  REGISTER: '/register',
 } as const
 
 const routes = [
   { path: ROUTES.HOME, component: HomePage, meta: { requiresAuth: true } },
+  {
+    path: ROUTES.CONNEXION,
+    component: ConnexionPage,
+    meta: { requiresAuth: true },
+  },
+  {
+    path: ROUTES.REGISTER,
+    component: InscriptionPage,
+    meta: { requiresAuth: true },
+  },
 ]
 
 const router = createRouter({

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import { useAuthStore } from '@/store/auth.store'
+
 import ConnexionPage from './pages/ConnexionPage.vue'
 import HomePage from './pages/HomePage.vue'
 import InscriptionPage from './pages/InscriptionPage.vue'
@@ -11,22 +13,48 @@ export const ROUTES = {
 } as const
 
 const routes = [
-  { path: ROUTES.HOME, component: HomePage, meta: { requiresAuth: true } },
+  {
+    path: ROUTES.HOME,
+    component: HomePage,
+    meta: { requiresAuth: true },
+  },
   {
     path: ROUTES.CONNEXION,
     component: ConnexionPage,
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: false },
   },
   {
     path: ROUTES.REGISTER,
     component: InscriptionPage,
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: false },
   },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+//  Protection des routes
+router.beforeEach((to, from, next) => {
+  const authStore = useAuthStore()
+
+  //  Pas connecté → accès refusé aux pages protégées
+  if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+    return next(ROUTES.CONNEXION)
+  }
+
+  // Déjà connecté → empêche d'aller sur login/register
+  if (
+    !to.meta.requiresAuth &&
+    authStore.isAuthenticated &&
+    (to.path === ROUTES.CONNEXION || to.path === ROUTES.REGISTER)
+  ) {
+    return next(ROUTES.HOME)
+  }
+
+  //  Sinon tout passe
+  next()
 })
 
 export default router

--- a/src/router.ts
+++ b/src/router.ts
@@ -36,7 +36,7 @@ const router = createRouter({
 })
 
 //  Protection des routes
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, _from, next) => {
   const authStore = useAuthStore()
 
   //  Pas connecté → accès refusé aux pages protégées

--- a/src/store/auth.store.ts
+++ b/src/store/auth.store.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+import { useStorage } from '@/composables/useStorage'
+import type { User } from '@/types'
+
+export const useAuthStore = defineStore('auth', () => {
+  const storage = useStorage()
+
+  const token = ref<string | null>(storage.get('token'))
+  const user = ref<User | null>(storage.get('user'))
+
+  const isAuthenticated = computed(() => token.value !== null)
+
+  function login(newToken: string, newUser: User) {
+    token.value = newToken
+    user.value = newUser
+
+    storage.set('token', newToken)
+    storage.set('user', newUser)
+  }
+
+  function logout() {
+    token.value = null
+    user.value = null
+
+    storage.remove('token')
+    storage.remove('user')
+  }
+
+  return {
+    token,
+    user,
+    isAuthenticated,
+    login,
+    logout,
+  }
+})


### PR DESCRIPTION
Règles de gestion :
L'état de connexion (token + informations utilisateur) est persisté et restauré au rechargement Toute route privée redirige vers la page de connexion si l'utilisateur n'est pas authentifié Les pages de connexion et d'inscription sont inaccessibles si l'utilisateur est déjà connecté La barre de navigation n'est affichée que si l'utilisateur est connecté La barre de navigation affiche le nom d'utilisateur connecté La barre de navigation propose un bouton de déconnexion qui redirige vers la page de connexion

Page de connexion :
Le formulaire contient les champs email et mot de passe Le bouton de soumission est désactivé pendant l'appel à l'API Un message d'erreur s'affiche si les identifiants sont incorrects L'utilisateur est redirigé vers la page d'accueil après connexion réussie Un lien vers la page d'inscription est visible

Page d'inscription :
Le formulaire contient les champs username, email et mot de passe Le bouton de soumission est désactivé pendant l'appel à l'API Un message d'erreur s'affiche en cas d'échec de l'inscription L'utilisateur est redirigé vers la page d'accueil après inscription réussie Un lien vers la page de connexion est visible